### PR TITLE
Handle more cases in derefAddress

### DIFF
--- a/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Add1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/And1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AndRef.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args4.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Args5.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAdd1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgAnd1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgOr1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgSub1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/AsgXor1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/BinaryRMW.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Call1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11777,15 +11777,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 104
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12172,15 +12172,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12331,15 +12331,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12436,15 +12436,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12535,15 +12535,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12683,15 +12683,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12760,15 +12760,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13227,15 +13227,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13347,15 +13347,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13395,15 +13395,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13432,15 +13432,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13458,15 +13458,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13579,15 +13579,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13675,15 +13675,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13779,15 +13779,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13832,15 +13832,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13888,15 +13888,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13910,15 +13910,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14177,15 +14177,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14222,15 +14222,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14269,15 +14269,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14312,15 +14312,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14342,15 +14342,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14516,15 +14516,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14815,15 +14815,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 104
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -15645,15 +15645,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -15832,15 +15832,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -16194,15 +16194,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsBool.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/CnsLng1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAdd.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAddConst.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArea.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11789,15 +11789,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12184,15 +12184,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12343,15 +12343,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12448,15 +12448,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12547,15 +12547,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12695,15 +12695,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12772,15 +12772,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13239,15 +13239,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13359,15 +13359,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13407,15 +13407,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13470,15 +13470,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13591,15 +13591,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13687,15 +13687,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13791,15 +13791,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13844,15 +13844,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13900,15 +13900,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13922,15 +13922,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14189,15 +14189,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14234,15 +14234,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14281,15 +14281,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14324,15 +14324,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14354,15 +14354,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14528,15 +14528,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14827,15 +14827,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14884,30 +14884,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14936,15 +14936,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14952,15 +14952,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17057,15 +17057,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17244,15 +17244,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17606,15 +17606,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17653,15 +17653,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblArray.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11824,15 +11824,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12219,15 +12219,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12378,15 +12378,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12483,15 +12483,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12582,15 +12582,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12730,15 +12730,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12807,15 +12807,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13274,15 +13274,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13394,15 +13394,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13442,15 +13442,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13479,15 +13479,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13505,15 +13505,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13626,15 +13626,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13722,15 +13722,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13826,15 +13826,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13879,15 +13879,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13935,15 +13935,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13957,15 +13957,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14224,15 +14224,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14269,15 +14269,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14316,15 +14316,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14359,15 +14359,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14389,15 +14389,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14563,15 +14563,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14862,15 +14862,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14919,30 +14919,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14971,15 +14971,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14987,15 +14987,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17092,15 +17092,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17279,15 +17279,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17641,15 +17641,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17688,15 +17688,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg2.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11770,15 +11770,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12165,15 +12165,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12324,15 +12324,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12429,15 +12429,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12528,15 +12528,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12676,15 +12676,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12753,15 +12753,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13220,15 +13220,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13340,15 +13340,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13388,15 +13388,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13425,15 +13425,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13451,15 +13451,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13572,15 +13572,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13668,15 +13668,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13772,15 +13772,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13825,15 +13825,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13881,15 +13881,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13903,15 +13903,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14170,15 +14170,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14215,15 +14215,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14262,15 +14262,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14305,15 +14305,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14335,15 +14335,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14509,15 +14509,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14808,15 +14808,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14865,30 +14865,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14917,15 +14917,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14933,15 +14933,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17038,15 +17038,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17225,15 +17225,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17587,15 +17587,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17634,15 +17634,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblAvg6.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11786,15 +11786,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12181,15 +12181,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12340,15 +12340,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12445,15 +12445,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12544,15 +12544,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12692,15 +12692,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12769,15 +12769,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13236,15 +13236,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13356,15 +13356,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13404,15 +13404,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13441,15 +13441,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13467,15 +13467,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13588,15 +13588,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13684,15 +13684,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13788,15 +13788,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13841,15 +13841,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13897,15 +13897,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13919,15 +13919,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14186,15 +14186,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14231,15 +14231,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14278,15 +14278,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14321,15 +14321,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14351,15 +14351,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14525,15 +14525,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14824,15 +14824,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14881,30 +14881,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14933,15 +14933,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14949,15 +14949,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17054,15 +17054,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17241,15 +17241,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17603,15 +17603,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17650,15 +17650,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11783,15 +11783,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12178,15 +12178,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12337,15 +12337,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12442,15 +12442,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12541,15 +12541,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12689,15 +12689,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12766,15 +12766,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13233,15 +13233,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13353,15 +13353,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13401,15 +13401,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13438,15 +13438,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13464,15 +13464,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13585,15 +13585,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13681,15 +13681,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13785,15 +13785,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13838,15 +13838,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13894,15 +13894,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13916,15 +13916,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14183,15 +14183,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14228,15 +14228,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14275,15 +14275,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14318,15 +14318,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14348,15 +14348,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14522,15 +14522,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14821,15 +14821,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14878,30 +14878,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14930,15 +14930,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14946,15 +14946,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17051,15 +17051,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17238,15 +17238,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17600,15 +17600,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17647,15 +17647,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblCall2.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11793,15 +11793,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12188,15 +12188,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12347,15 +12347,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12452,15 +12452,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12551,15 +12551,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12699,15 +12699,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12776,15 +12776,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13243,15 +13243,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13363,15 +13363,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13411,15 +13411,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13448,15 +13448,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13474,15 +13474,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13595,15 +13595,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13691,15 +13691,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13795,15 +13795,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13848,15 +13848,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13904,15 +13904,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13926,15 +13926,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14193,15 +14193,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14238,15 +14238,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14285,15 +14285,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14328,15 +14328,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14358,15 +14358,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14532,15 +14532,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14831,15 +14831,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14888,30 +14888,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14940,15 +14940,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14956,15 +14956,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17061,15 +17061,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17248,15 +17248,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17610,15 +17610,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17657,15 +17657,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDist.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11788,15 +11788,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12183,15 +12183,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12342,15 +12342,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12447,15 +12447,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12546,15 +12546,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12694,15 +12694,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12771,15 +12771,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13238,15 +13238,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13358,15 +13358,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13406,15 +13406,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13443,15 +13443,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13469,15 +13469,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13590,15 +13590,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13686,15 +13686,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13790,15 +13790,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13843,15 +13843,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13899,15 +13899,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13921,15 +13921,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14188,15 +14188,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14233,15 +14233,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14280,15 +14280,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14323,15 +14323,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14353,15 +14353,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14527,15 +14527,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14826,15 +14826,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14883,30 +14883,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14935,15 +14935,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14951,15 +14951,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17056,15 +17056,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17243,15 +17243,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17605,15 +17605,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17652,15 +17652,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDiv.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblDivConst.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblFillArray.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11837,15 +11837,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12232,15 +12232,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12391,15 +12391,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12496,15 +12496,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12595,15 +12595,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12743,15 +12743,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12820,15 +12820,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13287,15 +13287,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13407,15 +13407,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13455,15 +13455,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13492,15 +13492,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13518,15 +13518,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13639,15 +13639,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13735,15 +13735,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13839,15 +13839,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13892,15 +13892,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13948,15 +13948,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13970,15 +13970,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14237,15 +14237,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14282,15 +14282,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14329,15 +14329,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14372,15 +14372,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14402,15 +14402,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14576,15 +14576,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14875,15 +14875,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14932,30 +14932,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14984,15 +14984,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -15000,15 +15000,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17105,15 +17105,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17292,15 +17292,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17654,15 +17654,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17701,15 +17701,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMul.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblMulConst.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11765,15 +11765,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12160,15 +12160,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12319,15 +12319,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12424,15 +12424,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12523,15 +12523,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12671,15 +12671,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12748,15 +12748,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13215,15 +13215,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13335,15 +13335,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13383,15 +13383,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13420,15 +13420,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13446,15 +13446,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13567,15 +13567,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13663,15 +13663,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13767,15 +13767,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13820,15 +13820,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13876,15 +13876,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13898,15 +13898,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14165,15 +14165,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14210,15 +14210,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14257,15 +14257,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14300,15 +14300,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14330,15 +14330,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14504,15 +14504,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14803,15 +14803,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14860,30 +14860,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14912,15 +14912,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14928,15 +14928,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17033,15 +17033,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17220,15 +17220,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17582,15 +17582,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17629,15 +17629,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblNeg.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRem.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblRoots.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11789,45 +11789,45 @@ entry:
 
 ; <label>:17                                      ; preds = %11, %14
   %18 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %19 = bitcast %System.Object addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Object addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
   %28 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %29 = call %System.String addrspace(1)* %28(%System.Object addrspace(1)* %18)
   %30 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %31 = bitcast %System.Object addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Object addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %20
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 0
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
   %40 = inttoptr i64 %39 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %41 = call %System.String addrspace(1)* %40(%System.Object addrspace(1)* %30)
   %42 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
-  %43 = bitcast %System.Object addrspace(1)* %42 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %43, null
+  %43 = bitcast %System.Object addrspace(1)* %42 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %43, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %44
 
 ; <label>:44                                      ; preds = %32
-  %45 = load i64, i64 addrspace(1)* %43
-  %46 = add i64 %45, 64
-  %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %45 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %43
+  %46 = getelementptr inbounds i8, i8 addrspace(1)* %45, i32 64
+  %47 = bitcast i8 addrspace(1)* %46 to i64 addrspace(1)*
+  %48 = load i64, i64 addrspace(1)* %47
   %49 = add i64 %48, 0
   %50 = inttoptr i64 %49 to i64*
   %51 = load i64, i64* %50
@@ -13542,15 +13542,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 104
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -13937,15 +13937,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -14096,15 +14096,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -14201,15 +14201,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -14300,15 +14300,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -14448,15 +14448,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -14525,15 +14525,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -14992,15 +14992,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -15112,15 +15112,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -15160,15 +15160,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -15197,15 +15197,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -15223,15 +15223,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -15344,15 +15344,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -15440,15 +15440,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -15544,15 +15544,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -15597,15 +15597,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -15653,15 +15653,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -15675,15 +15675,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -15942,15 +15942,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -15987,15 +15987,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -16034,15 +16034,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -16077,15 +16077,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -16107,15 +16107,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -16281,15 +16281,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -16403,15 +16403,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 104
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -17233,15 +17233,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17420,15 +17420,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17782,15 +17782,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSub.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblSubConst.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/DblVar.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11769,15 +11769,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12164,15 +12164,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12323,15 +12323,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12428,15 +12428,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12527,15 +12527,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12675,15 +12675,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12752,15 +12752,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13219,15 +13219,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13339,15 +13339,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13387,15 +13387,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13424,15 +13424,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13450,15 +13450,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13571,15 +13571,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13667,15 +13667,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13771,15 +13771,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13824,15 +13824,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13880,15 +13880,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13902,15 +13902,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14169,15 +14169,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14214,15 +14214,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14261,15 +14261,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14304,15 +14304,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14334,15 +14334,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14508,15 +14508,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14807,15 +14807,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14864,30 +14864,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14916,15 +14916,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14932,15 +14932,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17037,15 +17037,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17224,15 +17224,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17586,15 +17586,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17633,15 +17633,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Eq1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAdd.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAddConst.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArea.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11789,15 +11789,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12184,15 +12184,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12343,15 +12343,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12448,15 +12448,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12547,15 +12547,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12695,15 +12695,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12772,15 +12772,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13239,15 +13239,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13359,15 +13359,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13407,15 +13407,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13470,15 +13470,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13591,15 +13591,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13687,15 +13687,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13791,15 +13791,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13844,15 +13844,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13900,15 +13900,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13922,15 +13922,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14189,15 +14189,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14234,15 +14234,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14281,15 +14281,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14324,15 +14324,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14354,15 +14354,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14528,15 +14528,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14827,15 +14827,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14884,30 +14884,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14936,15 +14936,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14952,15 +14952,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17057,15 +17057,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17244,15 +17244,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17606,15 +17606,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17653,15 +17653,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPArray.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11824,15 +11824,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12219,15 +12219,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12378,15 +12378,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12483,15 +12483,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12582,15 +12582,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12730,15 +12730,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12807,15 +12807,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13274,15 +13274,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13394,15 +13394,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13442,15 +13442,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13479,15 +13479,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13505,15 +13505,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13626,15 +13626,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13722,15 +13722,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13826,15 +13826,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13879,15 +13879,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13935,15 +13935,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13957,15 +13957,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14224,15 +14224,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14269,15 +14269,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14316,15 +14316,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14359,15 +14359,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14389,15 +14389,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14563,15 +14563,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14862,15 +14862,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14919,30 +14919,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14971,15 +14971,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14987,15 +14987,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17092,15 +17092,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17279,15 +17279,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17641,15 +17641,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17688,15 +17688,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg2.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11770,15 +11770,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12165,15 +12165,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12324,15 +12324,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12429,15 +12429,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12528,15 +12528,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12676,15 +12676,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12753,15 +12753,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13220,15 +13220,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13340,15 +13340,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13388,15 +13388,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13425,15 +13425,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13451,15 +13451,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13572,15 +13572,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13668,15 +13668,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13772,15 +13772,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13825,15 +13825,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13881,15 +13881,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13903,15 +13903,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14170,15 +14170,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14215,15 +14215,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14262,15 +14262,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14305,15 +14305,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14335,15 +14335,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14509,15 +14509,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14808,15 +14808,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14865,30 +14865,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14917,15 +14917,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14933,15 +14933,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17038,15 +17038,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17225,15 +17225,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17587,15 +17587,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17634,15 +17634,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPAvg6.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11786,15 +11786,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12181,15 +12181,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12340,15 +12340,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12445,15 +12445,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12544,15 +12544,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12692,15 +12692,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12769,15 +12769,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13236,15 +13236,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13356,15 +13356,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13404,15 +13404,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13441,15 +13441,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13467,15 +13467,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13588,15 +13588,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13684,15 +13684,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13788,15 +13788,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13841,15 +13841,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13897,15 +13897,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13919,15 +13919,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14186,15 +14186,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14231,15 +14231,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14278,15 +14278,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14321,15 +14321,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14351,15 +14351,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14525,15 +14525,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14824,15 +14824,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14881,30 +14881,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14933,15 +14933,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14949,15 +14949,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17054,15 +17054,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17241,15 +17241,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17603,15 +17603,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17650,15 +17650,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11783,15 +11783,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12178,15 +12178,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12337,15 +12337,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12442,15 +12442,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12541,15 +12541,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12689,15 +12689,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12766,15 +12766,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13233,15 +13233,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13353,15 +13353,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13401,15 +13401,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13438,15 +13438,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13464,15 +13464,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13585,15 +13585,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13681,15 +13681,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13785,15 +13785,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13838,15 +13838,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13894,15 +13894,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13916,15 +13916,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14183,15 +14183,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14228,15 +14228,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14275,15 +14275,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14318,15 +14318,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14348,15 +14348,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14522,15 +14522,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14821,15 +14821,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14878,30 +14878,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14930,15 +14930,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14946,15 +14946,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17051,15 +17051,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17238,15 +17238,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17600,15 +17600,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17647,15 +17647,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPCall2.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11793,15 +11793,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12188,15 +12188,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12347,15 +12347,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12452,15 +12452,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12551,15 +12551,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12699,15 +12699,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12776,15 +12776,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13243,15 +13243,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13363,15 +13363,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13411,15 +13411,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13448,15 +13448,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13474,15 +13474,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13595,15 +13595,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13691,15 +13691,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13795,15 +13795,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13848,15 +13848,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13904,15 +13904,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13926,15 +13926,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14193,15 +14193,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14238,15 +14238,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14285,15 +14285,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14328,15 +14328,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14358,15 +14358,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14532,15 +14532,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14831,15 +14831,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14888,30 +14888,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14940,15 +14940,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14956,15 +14956,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17061,15 +17061,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17248,15 +17248,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17610,15 +17610,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17657,15 +17657,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvDbl2Lng.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11814,15 +11814,15 @@ entry:
   store i64 %param0, i64* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12209,15 +12209,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12368,15 +12368,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12473,15 +12473,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12572,15 +12572,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12720,15 +12720,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12797,15 +12797,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13264,15 +13264,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13384,15 +13384,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13432,15 +13432,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13469,15 +13469,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13495,15 +13495,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13616,15 +13616,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13712,15 +13712,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13816,15 +13816,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13869,15 +13869,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13925,15 +13925,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13947,15 +13947,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14214,15 +14214,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14259,15 +14259,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14306,15 +14306,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14349,15 +14349,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14379,15 +14379,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14553,15 +14553,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14852,15 +14852,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 32
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14909,30 +14909,30 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14961,15 +14961,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14977,15 +14977,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17082,15 +17082,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17269,15 +17269,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17631,15 +17631,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17678,15 +17678,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -17924,15 +17924,15 @@ entry:
   store i64 %param0, i64* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -17976,15 +17976,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 40
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -18033,30 +18033,30 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 24
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -18085,15 +18085,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -18101,15 +18101,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2F.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -17873,15 +17873,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -17925,15 +17925,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -17982,30 +17982,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -18034,15 +18034,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -18050,15 +18050,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2I.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11818,15 +11818,15 @@ entry:
   store i32 %param0, i32* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12213,15 +12213,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12372,15 +12372,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12477,15 +12477,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12576,15 +12576,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12724,15 +12724,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12801,15 +12801,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13268,15 +13268,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13388,15 +13388,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13436,15 +13436,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13473,15 +13473,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13499,15 +13499,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13620,15 +13620,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13716,15 +13716,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13820,15 +13820,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13873,15 +13873,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13929,15 +13929,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13951,15 +13951,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14218,15 +14218,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14263,15 +14263,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14310,15 +14310,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14353,15 +14353,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14383,15 +14383,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14557,15 +14557,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14856,15 +14856,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14913,30 +14913,30 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14965,15 +14965,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14981,15 +14981,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17086,15 +17086,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17273,15 +17273,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17635,15 +17635,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17682,15 +17682,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvF2Lng.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11814,15 +11814,15 @@ entry:
   store i64 %param0, i64* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12209,15 +12209,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12368,15 +12368,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12473,15 +12473,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12572,15 +12572,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12720,15 +12720,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12797,15 +12797,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13264,15 +13264,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13384,15 +13384,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13432,15 +13432,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13469,15 +13469,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13495,15 +13495,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13616,15 +13616,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13712,15 +13712,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13816,15 +13816,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13869,15 +13869,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13925,15 +13925,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13947,15 +13947,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14214,15 +14214,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14259,15 +14259,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14306,15 +14306,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14349,15 +14349,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14379,15 +14379,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14553,15 +14553,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14852,15 +14852,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 32
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14909,30 +14909,30 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14961,15 +14961,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14977,15 +14977,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17082,15 +17082,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17269,15 +17269,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17631,15 +17631,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17678,15 +17678,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -17924,15 +17924,15 @@ entry:
   store i64 %param0, i64* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -17976,15 +17976,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 40
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -18033,30 +18033,30 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 24
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -18085,15 +18085,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -18101,15 +18101,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.UInt64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPConvI2F.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -17873,15 +17873,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -17925,15 +17925,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -17982,30 +17982,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -18034,15 +18034,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -18050,15 +18050,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDist.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11753,15 +11753,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12148,15 +12148,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12307,15 +12307,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12412,15 +12412,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12511,15 +12511,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12659,15 +12659,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12736,15 +12736,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13203,15 +13203,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13323,15 +13323,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13371,15 +13371,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13408,15 +13408,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13434,15 +13434,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13555,15 +13555,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13651,15 +13651,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13755,15 +13755,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13808,15 +13808,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13864,15 +13864,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13886,15 +13886,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14153,15 +14153,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14198,15 +14198,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14245,15 +14245,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14288,15 +14288,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14318,15 +14318,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14492,15 +14492,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14791,15 +14791,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14848,30 +14848,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14900,15 +14900,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14916,15 +14916,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17021,15 +17021,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17208,15 +17208,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17570,15 +17570,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17617,15 +17617,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDiv.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPDivConst.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPError.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11770,15 +11770,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12165,15 +12165,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12324,15 +12324,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12429,15 +12429,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12528,15 +12528,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12676,15 +12676,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12753,15 +12753,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13220,15 +13220,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13340,15 +13340,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13388,15 +13388,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13425,15 +13425,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13451,15 +13451,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13572,15 +13572,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13668,15 +13668,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13772,15 +13772,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13825,15 +13825,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13881,15 +13881,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13903,15 +13903,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14170,15 +14170,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14215,15 +14215,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14262,15 +14262,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14305,15 +14305,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14335,15 +14335,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14509,15 +14509,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14808,15 +14808,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14865,30 +14865,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14917,15 +14917,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14933,15 +14933,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17038,15 +17038,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17225,15 +17225,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17587,15 +17587,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17634,15 +17634,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPFillArray.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11837,15 +11837,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12232,15 +12232,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12391,15 +12391,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12496,15 +12496,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12595,15 +12595,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12743,15 +12743,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12820,15 +12820,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13287,15 +13287,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13407,15 +13407,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13455,15 +13455,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13492,15 +13492,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13518,15 +13518,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13639,15 +13639,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13735,15 +13735,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13839,15 +13839,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13892,15 +13892,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13948,15 +13948,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13970,15 +13970,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14237,15 +14237,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14282,15 +14282,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14329,15 +14329,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14372,15 +14372,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14402,15 +14402,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14576,15 +14576,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14875,15 +14875,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14932,30 +14932,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14984,15 +14984,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -15000,15 +15000,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17105,15 +17105,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17292,15 +17292,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17654,15 +17654,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17701,15 +17701,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMath.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11755,15 +11755,15 @@ entry:
   store double %param0, double* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load double, double* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 56
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12150,15 +12150,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12309,15 +12309,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12414,15 +12414,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12513,15 +12513,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12661,15 +12661,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12738,15 +12738,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13205,15 +13205,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13325,15 +13325,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13373,15 +13373,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13410,15 +13410,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13436,15 +13436,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13557,15 +13557,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13653,15 +13653,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13757,15 +13757,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13810,15 +13810,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13866,15 +13866,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13888,15 +13888,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14155,15 +14155,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14200,15 +14200,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14247,15 +14247,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14290,15 +14290,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14320,15 +14320,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14494,15 +14494,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14793,15 +14793,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load double, double* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 56
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14850,30 +14850,30 @@ entry:
   store double %param1, double* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load double, double* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, double)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, double %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14902,15 +14902,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast double* %arg1 to double addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14918,15 +14918,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast double addrspace(1)* %1 to %System.Double addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Double addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Double addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17023,15 +17023,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17210,15 +17210,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17572,15 +17572,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17619,15 +17619,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMul.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPMulConst.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11765,15 +11765,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12160,15 +12160,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12319,15 +12319,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12424,15 +12424,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12523,15 +12523,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12671,15 +12671,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12748,15 +12748,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13215,15 +13215,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13335,15 +13335,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13383,15 +13383,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13420,15 +13420,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13446,15 +13446,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13567,15 +13567,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13663,15 +13663,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13767,15 +13767,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13820,15 +13820,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13876,15 +13876,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13898,15 +13898,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14165,15 +14165,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14210,15 +14210,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14257,15 +14257,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14300,15 +14300,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14330,15 +14330,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14504,15 +14504,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14803,15 +14803,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14860,30 +14860,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14912,15 +14912,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14928,15 +14928,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17033,15 +17033,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17220,15 +17220,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17582,15 +17582,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17629,15 +17629,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPNeg.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRem.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPRoots.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11753,15 +11753,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12148,15 +12148,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12307,15 +12307,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12412,15 +12412,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12511,15 +12511,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12659,15 +12659,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12736,15 +12736,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13203,15 +13203,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13323,15 +13323,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13371,15 +13371,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13408,15 +13408,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13434,15 +13434,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13555,15 +13555,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13651,15 +13651,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13755,15 +13755,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13808,15 +13808,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13864,15 +13864,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13886,15 +13886,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14153,15 +14153,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14198,15 +14198,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14245,15 +14245,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14288,15 +14288,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14318,15 +14318,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14492,15 +14492,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14791,15 +14791,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14848,30 +14848,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14900,15 +14900,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14916,15 +14916,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17021,15 +17021,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17208,15 +17208,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17570,15 +17570,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17617,15 +17617,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -17887,45 +17887,45 @@ entry:
 
 ; <label>:17                                      ; preds = %11, %14
   %18 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %19 = bitcast %System.Object addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Object addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
   %28 = inttoptr i64 %27 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %29 = call %System.String addrspace(1)* %28(%System.Object addrspace(1)* %18)
   %30 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %31 = bitcast %System.Object addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Object addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %20
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 0
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
   %40 = inttoptr i64 %39 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %41 = call %System.String addrspace(1)* %40(%System.Object addrspace(1)* %30)
   %42 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg2
-  %43 = bitcast %System.Object addrspace(1)* %42 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %43, null
+  %43 = bitcast %System.Object addrspace(1)* %42 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %43, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %44
 
 ; <label>:44                                      ; preds = %32
-  %45 = load i64, i64 addrspace(1)* %43
-  %46 = add i64 %45, 64
-  %47 = inttoptr i64 %46 to i64*
-  %48 = load i64, i64* %47
+  %45 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %43
+  %46 = getelementptr inbounds i8, i8 addrspace(1)* %45, i32 64
+  %47 = bitcast i8 addrspace(1)* %46 to i64 addrspace(1)*
+  %48 = load i64, i64 addrspace(1)* %47
   %49 = add i64 %48, 0
   %50 = inttoptr i64 %49 to i64*
   %51 = load i64, i64* %50
@@ -18140,15 +18140,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 104
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -18192,15 +18192,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 104
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSmall.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11781,15 +11781,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12176,15 +12176,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12335,15 +12335,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12440,15 +12440,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12539,15 +12539,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12687,15 +12687,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12764,15 +12764,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13231,15 +13231,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13351,15 +13351,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13399,15 +13399,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13436,15 +13436,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13462,15 +13462,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13583,15 +13583,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13679,15 +13679,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13783,15 +13783,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13836,15 +13836,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13892,15 +13892,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13914,15 +13914,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14181,15 +14181,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14226,15 +14226,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14273,15 +14273,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14316,15 +14316,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14346,15 +14346,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14520,15 +14520,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14819,15 +14819,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14876,30 +14876,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14928,15 +14928,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14944,15 +14944,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17049,15 +17049,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17236,15 +17236,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17598,15 +17598,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17645,15 +17645,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSub.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11766,15 +11766,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12161,15 +12161,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12320,15 +12320,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12425,15 +12425,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12524,15 +12524,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12672,15 +12672,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12749,15 +12749,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13216,15 +13216,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13336,15 +13336,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13384,15 +13384,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13421,15 +13421,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13447,15 +13447,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13568,15 +13568,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13664,15 +13664,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13768,15 +13768,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13821,15 +13821,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13877,15 +13877,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13899,15 +13899,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14166,15 +14166,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14211,15 +14211,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14258,15 +14258,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14301,15 +14301,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14331,15 +14331,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14505,15 +14505,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14804,15 +14804,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14861,30 +14861,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14913,15 +14913,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14929,15 +14929,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17034,15 +17034,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17221,15 +17221,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17583,15 +17583,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17630,15 +17630,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPSubConst.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11763,15 +11763,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12158,15 +12158,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12317,15 +12317,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12422,15 +12422,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12521,15 +12521,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12669,15 +12669,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12746,15 +12746,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13213,15 +13213,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13333,15 +13333,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13381,15 +13381,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13418,15 +13418,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13444,15 +13444,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13565,15 +13565,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13661,15 +13661,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13765,15 +13765,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13818,15 +13818,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13874,15 +13874,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13896,15 +13896,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14163,15 +14163,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14208,15 +14208,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14255,15 +14255,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14298,15 +14298,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14328,15 +14328,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14502,15 +14502,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14801,15 +14801,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14858,30 +14858,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14910,15 +14910,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14926,15 +14926,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17031,15 +17031,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17218,15 +17218,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17580,15 +17580,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17627,15 +17627,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FPVar.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11769,15 +11769,15 @@ entry:
   store float %param0, float* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load float, float* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 48
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12164,15 +12164,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12323,15 +12323,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12428,15 +12428,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12527,15 +12527,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12675,15 +12675,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12752,15 +12752,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13219,15 +13219,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13339,15 +13339,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13387,15 +13387,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13424,15 +13424,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13450,15 +13450,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13571,15 +13571,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13667,15 +13667,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13771,15 +13771,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13824,15 +13824,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13880,15 +13880,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13902,15 +13902,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14169,15 +14169,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14214,15 +14214,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14261,15 +14261,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14304,15 +14304,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14334,15 +14334,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14508,15 +14508,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14807,15 +14807,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load float, float* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 48
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14864,30 +14864,30 @@ entry:
   store float %param1, float* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load float, float* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, float)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, float %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14916,15 +14916,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast float* %arg1 to float addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14932,15 +14932,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast float addrspace(1)* %1 to %System.Single addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Single addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Single addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17037,15 +17037,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17224,15 +17224,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17586,15 +17586,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17633,15 +17633,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FactorialRec.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11800,15 +11800,15 @@ entry:
   store i32 %param0, i32* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12195,15 +12195,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12354,15 +12354,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12459,15 +12459,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12558,15 +12558,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12706,15 +12706,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12783,15 +12783,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13250,15 +13250,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13370,15 +13370,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13418,15 +13418,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13455,15 +13455,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13481,15 +13481,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13602,15 +13602,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13698,15 +13698,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13802,15 +13802,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13855,15 +13855,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13911,15 +13911,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13933,15 +13933,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14200,15 +14200,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14245,15 +14245,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14292,15 +14292,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14335,15 +14335,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14365,15 +14365,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14539,15 +14539,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14838,15 +14838,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14895,30 +14895,30 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14947,15 +14947,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -14963,15 +14963,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17068,15 +17068,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17255,15 +17255,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17617,15 +17617,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17664,15 +17664,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FibLoop.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/FiboRec.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gcd.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -13452,15 +13452,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 104
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -13847,15 +13847,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -14006,15 +14006,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -14111,15 +14111,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -14210,15 +14210,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -14358,15 +14358,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -14435,15 +14435,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -14902,15 +14902,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -15022,15 +15022,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -15070,15 +15070,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -15107,15 +15107,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -15133,15 +15133,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -15254,15 +15254,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -15350,15 +15350,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -15454,15 +15454,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -15507,15 +15507,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -15563,15 +15563,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -15585,15 +15585,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -15852,15 +15852,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -15897,15 +15897,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -15944,15 +15944,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -15987,15 +15987,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -16017,15 +16017,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -16191,15 +16191,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -16313,15 +16313,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 104
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -17143,15 +17143,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17330,15 +17330,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17692,15 +17692,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17756,30 +17756,30 @@ entry:
 
 ; <label>:11                                      ; preds = %5, %8
   %12 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg0
-  %13 = bitcast %System.Object addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Object addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck, label %ThrowNullRef, label %14
 
 ; <label>:14                                      ; preds = %11
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 64
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 64
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 0
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
   %22 = inttoptr i64 %21 to %System.String addrspace(1)* (%System.Object addrspace(1)*)*
   %23 = call %System.String addrspace(1)* %22(%System.Object addrspace(1)* %12)
   %24 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %25 = bitcast %System.Object addrspace(1)* %24 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Object addrspace(1)* %24 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %26
 
 ; <label>:26                                      ; preds = %14
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 0
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ge1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Gt1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ind1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InitObj.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/InstanceCalls.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntArraySum.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/IntConv.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11849,15 +11849,15 @@ entry:
   store i64 %param0, i64* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i64, i64* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 32
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12244,15 +12244,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12403,15 +12403,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12508,15 +12508,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12607,15 +12607,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12755,15 +12755,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12832,15 +12832,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13299,15 +13299,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13419,15 +13419,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13467,15 +13467,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13504,15 +13504,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13530,15 +13530,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13651,15 +13651,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13747,15 +13747,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13851,15 +13851,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13904,15 +13904,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13960,15 +13960,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13982,15 +13982,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14249,15 +14249,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14294,15 +14294,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14341,15 +14341,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14384,15 +14384,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14414,15 +14414,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14588,15 +14588,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14887,15 +14887,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i64, i64* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 32
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -14944,30 +14944,30 @@ entry:
   store i64 %param1, i64* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i64, i64* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i64)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i64 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14996,15 +14996,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i64* %arg1 to i64 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -15012,15 +15012,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i64 addrspace(1)* %1 to %System.Int64 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int64 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int64 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17117,15 +17117,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17304,15 +17304,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17666,15 +17666,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17713,15 +17713,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -17971,15 +17971,15 @@ entry:
   store i32 %param0, i32* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -18023,15 +18023,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -18080,30 +18080,30 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -18132,15 +18132,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -18148,15 +18148,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -18247,15 +18247,15 @@ entry:
   store i32 %param0, i32* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 24
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -18299,15 +18299,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 24
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -18356,30 +18356,30 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -18408,15 +18408,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -18424,15 +18424,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrue1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqDbl.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqFP.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueEqInt1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeDbl.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeFP.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGeInt1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtDbl.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtFP.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueGtInt1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeDbl.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeFP.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLeInt1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtDbl.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtFP.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueLtInt1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeDbl.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeFP.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/JTrueNeInt1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Jmp1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Le1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LeftShift.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LngConv.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11926,15 +11926,15 @@ entry:
   store i32 %param0, i32* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 24
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12321,15 +12321,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12480,15 +12480,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12585,15 +12585,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12684,15 +12684,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12832,15 +12832,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12909,15 +12909,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13376,15 +13376,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13496,15 +13496,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13544,15 +13544,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13581,15 +13581,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13607,15 +13607,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13728,15 +13728,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13824,15 +13824,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13928,15 +13928,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13981,15 +13981,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -14037,15 +14037,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -14059,15 +14059,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14326,15 +14326,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14371,15 +14371,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14418,15 +14418,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14461,15 +14461,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14491,15 +14491,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14665,15 +14665,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14964,15 +14964,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 24
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -15021,30 +15021,30 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -15073,15 +15073,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -15089,15 +15089,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.UInt32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.UInt32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.UInt32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17194,15 +17194,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17381,15 +17381,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17743,15 +17743,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -17790,15 +17790,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -18051,15 +18051,15 @@ entry:
   store i32 %param0, i32* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -18103,15 +18103,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -18160,30 +18160,30 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -18212,15 +18212,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -18228,15 +18228,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23

--- a/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/LongArgsAndReturn.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Lt1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Ne1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NegRMW.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NestedCall.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotAndNeg.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/NotRMW.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/ObjAlloc.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OpMembersOfStructLocal.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Or1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/OrRef.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/RightShiftRef.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StaticCalls.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12340,15 +12340,15 @@ entry:
   store i32 %param0, i32* %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load i32, i32* %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 96
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 96
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 16
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12735,15 +12735,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12894,15 +12894,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12999,15 +12999,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -13098,15 +13098,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -13246,15 +13246,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -13323,15 +13323,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13790,15 +13790,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13910,15 +13910,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13958,15 +13958,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13995,15 +13995,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -14021,15 +14021,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -14142,15 +14142,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -14238,15 +14238,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -14342,15 +14342,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -14395,15 +14395,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -14451,15 +14451,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -14473,15 +14473,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14740,15 +14740,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14785,15 +14785,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14832,15 +14832,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14875,15 +14875,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14905,15 +14905,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -15079,15 +15079,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -15378,15 +15378,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load i32, i32* %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 96
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 96
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 16
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -15435,30 +15435,30 @@ entry:
   store i32 %param1, i32* %arg1
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = load i32, i32* %arg1
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 80
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 80
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 0
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
   %11 = inttoptr i64 %10 to void (%System.IO.TextWriter addrspace(1)*, i32)*
   call void %11(%System.IO.TextWriter addrspace(1)* %0, i32 %1)
   %12 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.IO.TextWriter addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %14
 
 ; <label>:14                                      ; preds = %3
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 88
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 88
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 40
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -15487,15 +15487,15 @@ entry:
   %0 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
   %1 = addrspacecast i32* %arg1 to i32 addrspace(1)*
   %2 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %this
-  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.IO.TextWriter addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 32
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -15503,15 +15503,15 @@ entry:
   %13 = call %System.IFormatProvider addrspace(1)* %12(%System.IO.TextWriter addrspace(1)* %2)
   %14 = bitcast i32 addrspace(1)* %1 to %System.Int32 addrspace(1)*
   %15 = call %System.String addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.String addrspace(1)* (%System.Int32 addrspace(1)*, %System.IFormatProvider addrspace(1)*)*)(%System.Int32 addrspace(1)* %14, %System.IFormatProvider addrspace(1)* %13)
-  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %17
 
 ; <label>:17                                      ; preds = %4
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 80
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 80
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 56
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -17608,15 +17608,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17795,15 +17795,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -18157,15 +18157,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8
@@ -18204,15 +18204,15 @@ entry:
 ; <label>:2                                       ; preds = %entry
   %3 = getelementptr inbounds %System.IO.TextWriter, %System.IO.TextWriter addrspace(1)* %1, i32 0, i32 1
   %4 = load %"System.Char[]" addrspace(1)*, %"System.Char[]" addrspace(1)* addrspace(1)* %3, align 8
-  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %2
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 72
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 72
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 40
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructFldAddr.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/StructInstMethod.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Sub1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/SubRef.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Swap.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -13401,15 +13401,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 104
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -13796,15 +13796,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -13955,15 +13955,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -14060,15 +14060,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -14159,15 +14159,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -14307,15 +14307,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -14384,15 +14384,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -14851,15 +14851,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -14971,15 +14971,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -15019,15 +15019,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -15056,15 +15056,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -15082,15 +15082,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -15203,15 +15203,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -15299,15 +15299,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -15403,15 +15403,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -15456,15 +15456,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -15512,15 +15512,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -15534,15 +15534,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -15801,15 +15801,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -15846,15 +15846,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -15893,15 +15893,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -15936,15 +15936,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -15966,15 +15966,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -16140,15 +16140,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -16262,15 +16262,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 104
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -17092,15 +17092,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -17279,15 +17279,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -17641,15 +17641,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Switch.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Unbox.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/Xor1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/XorRef.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/addref.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/div1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/divref.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul2.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul3.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/mul4.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
+++ b/test/BaseLine/JIT/CodeGenBringUpTests/rem1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14

--- a/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/complex1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11751,15 +11751,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 104
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12146,15 +12146,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12305,15 +12305,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12410,15 +12410,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12509,15 +12509,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12657,15 +12657,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12734,15 +12734,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13201,15 +13201,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13321,15 +13321,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13369,15 +13369,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13406,15 +13406,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13432,15 +13432,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13553,15 +13553,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13649,15 +13649,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13753,15 +13753,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13806,15 +13806,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13862,15 +13862,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13884,15 +13884,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14151,15 +14151,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14196,15 +14196,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14243,15 +14243,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14286,15 +14286,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14316,15 +14316,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14490,15 +14490,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14789,15 +14789,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 104
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -15619,15 +15619,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -15806,15 +15806,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -16168,15 +16168,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8

--- a/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
+++ b/test/BaseLine/JIT/Directed/Arrays/simple1.error.txt
@@ -2283,15 +2283,15 @@ entry:
 
 ; <label>:24                                      ; preds = %20
   %25 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %26, null
+  %26 = bitcast %System.Globalization.CultureInfo addrspace(1)* %25 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %26, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %27
 
 ; <label>:27                                      ; preds = %24
-  %28 = load i64, i64 addrspace(1)* %26
-  %29 = add i64 %28, 72
-  %30 = inttoptr i64 %29 to i64*
-  %31 = load i64, i64* %30
+  %28 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %26
+  %29 = getelementptr inbounds i8, i8 addrspace(1)* %28, i32 72
+  %30 = bitcast i8 addrspace(1)* %29 to i64 addrspace(1)*
+  %31 = load i64, i64 addrspace(1)* %30
   %32 = add i64 %31, 16
   %33 = inttoptr i64 %32 to i64*
   %34 = load i64, i64* %33
@@ -2299,15 +2299,15 @@ entry:
   %36 = call %System.Globalization.CompareInfo addrspace(1)* %35(%System.Globalization.CultureInfo addrspace(1)* %25)
   %37 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %38 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %39, null
+  %39 = bitcast %System.Globalization.CompareInfo addrspace(1)* %36 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %39, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %40
 
 ; <label>:40                                      ; preds = %27
-  %41 = load i64, i64 addrspace(1)* %39
-  %42 = add i64 %41, 64
-  %43 = inttoptr i64 %42 to i64*
-  %44 = load i64, i64* %43
+  %41 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %39
+  %42 = getelementptr inbounds i8, i8 addrspace(1)* %41, i32 64
+  %43 = bitcast i8 addrspace(1)* %42 to i64 addrspace(1)*
+  %44 = load i64, i64 addrspace(1)* %43
   %45 = add i64 %44, 48
   %46 = inttoptr i64 %45 to i64*
   %47 = load i64, i64* %46
@@ -2317,15 +2317,15 @@ entry:
 
 ; <label>:50                                      ; preds = %20
   %51 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %52, null
+  %52 = bitcast %System.Globalization.CultureInfo addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %52, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %53
 
 ; <label>:53                                      ; preds = %50
-  %54 = load i64, i64 addrspace(1)* %52
-  %55 = add i64 %54, 72
-  %56 = inttoptr i64 %55 to i64*
-  %57 = load i64, i64* %56
+  %54 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %52
+  %55 = getelementptr inbounds i8, i8 addrspace(1)* %54, i32 72
+  %56 = bitcast i8 addrspace(1)* %55 to i64 addrspace(1)*
+  %57 = load i64, i64 addrspace(1)* %56
   %58 = add i64 %57, 16
   %59 = inttoptr i64 %58 to i64*
   %60 = load i64, i64* %59
@@ -2333,15 +2333,15 @@ entry:
   %62 = call %System.Globalization.CompareInfo addrspace(1)* %61(%System.Globalization.CultureInfo addrspace(1)* %51)
   %63 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %64 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.Globalization.CompareInfo addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %53
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 48
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -2351,15 +2351,15 @@ entry:
 
 ; <label>:76                                      ; preds = %20
   %77 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %78, null
+  %78 = bitcast %System.Globalization.CultureInfo addrspace(1)* %77 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %78, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %79
 
 ; <label>:79                                      ; preds = %76
-  %80 = load i64, i64 addrspace(1)* %78
-  %81 = add i64 %80, 72
-  %82 = inttoptr i64 %81 to i64*
-  %83 = load i64, i64* %82
+  %80 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %78
+  %81 = getelementptr inbounds i8, i8 addrspace(1)* %80, i32 72
+  %82 = bitcast i8 addrspace(1)* %81 to i64 addrspace(1)*
+  %83 = load i64, i64 addrspace(1)* %82
   %84 = add i64 %83, 16
   %85 = inttoptr i64 %84 to i64*
   %86 = load i64, i64* %85
@@ -2367,15 +2367,15 @@ entry:
   %88 = call %System.Globalization.CompareInfo addrspace(1)* %87(%System.Globalization.CultureInfo addrspace(1)* %77)
   %89 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %90 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %91, null
+  %91 = bitcast %System.Globalization.CompareInfo addrspace(1)* %88 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %91, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %92
 
 ; <label>:92                                      ; preds = %79
-  %93 = load i64, i64 addrspace(1)* %91
-  %94 = add i64 %93, 64
-  %95 = inttoptr i64 %94 to i64*
-  %96 = load i64, i64* %95
+  %93 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %91
+  %94 = getelementptr inbounds i8, i8 addrspace(1)* %93, i32 64
+  %95 = bitcast i8 addrspace(1)* %94 to i64 addrspace(1)*
+  %96 = load i64, i64 addrspace(1)* %95
   %97 = add i64 %96, 48
   %98 = inttoptr i64 %97 to i64*
   %99 = load i64, i64* %98
@@ -2385,15 +2385,15 @@ entry:
 
 ; <label>:102                                     ; preds = %20
   %103 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %104, null
+  %104 = bitcast %System.Globalization.CultureInfo addrspace(1)* %103 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %104, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %105
 
 ; <label>:105                                     ; preds = %102
-  %106 = load i64, i64 addrspace(1)* %104
-  %107 = add i64 %106, 72
-  %108 = inttoptr i64 %107 to i64*
-  %109 = load i64, i64* %108
+  %106 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %104
+  %107 = getelementptr inbounds i8, i8 addrspace(1)* %106, i32 72
+  %108 = bitcast i8 addrspace(1)* %107 to i64 addrspace(1)*
+  %109 = load i64, i64 addrspace(1)* %108
   %110 = add i64 %109, 16
   %111 = inttoptr i64 %110 to i64*
   %112 = load i64, i64* %111
@@ -2401,15 +2401,15 @@ entry:
   %114 = call %System.Globalization.CompareInfo addrspace(1)* %113(%System.Globalization.CultureInfo addrspace(1)* %103)
   %115 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %116 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %117, null
+  %117 = bitcast %System.Globalization.CompareInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %117, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %118
 
 ; <label>:118                                     ; preds = %105
-  %119 = load i64, i64 addrspace(1)* %117
-  %120 = add i64 %119, 64
-  %121 = inttoptr i64 %120 to i64*
-  %122 = load i64, i64* %121
+  %119 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %117
+  %120 = getelementptr inbounds i8, i8 addrspace(1)* %119, i32 64
+  %121 = bitcast i8 addrspace(1)* %120 to i64 addrspace(1)*
+  %122 = load i64, i64 addrspace(1)* %121
   %123 = add i64 %122, 48
   %124 = inttoptr i64 %123 to i64*
   %125 = load i64, i64* %124
@@ -2951,15 +2951,15 @@ entry:
 
 ; <label>:12                                      ; preds = %3
   %13 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %14 = bitcast %System.Type addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Type addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %12
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 152
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 152
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 32
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -2988,15 +2988,15 @@ entry:
 ; <label>:38                                      ; preds = %34
   %39 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
   %40 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %41 = bitcast %System.Type addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Type addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %42
 
 ; <label>:42                                      ; preds = %38
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 152
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 152
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 40
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -3033,15 +3033,15 @@ entry:
 
 ; <label>:70                                      ; preds = %56
   %71 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %72, null
+  %72 = bitcast %System.RuntimeType addrspace(1)* %71 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %72, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %73
 
 ; <label>:73                                      ; preds = %70
-  %74 = load i64, i64 addrspace(1)* %72
-  %75 = add i64 %74, 128
-  %76 = inttoptr i64 %75 to i64*
-  %77 = load i64, i64* %76
+  %74 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %72
+  %75 = getelementptr inbounds i8, i8 addrspace(1)* %74, i32 128
+  %76 = bitcast i8 addrspace(1)* %75 to i64 addrspace(1)*
+  %77 = load i64, i64 addrspace(1)* %76
   %78 = add i64 %77, 0
   %79 = inttoptr i64 %78 to i64*
   %80 = load i64, i64* %79
@@ -3054,15 +3054,15 @@ entry:
 
 ; <label>:86                                      ; preds = %73
   %87 = load %System.RuntimeType addrspace(1)*, %System.RuntimeType addrspace(1)** %this
-  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %88, null
+  %88 = bitcast %System.RuntimeType addrspace(1)* %87 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %88, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %89
 
 ; <label>:89                                      ; preds = %86
-  %90 = load i64, i64 addrspace(1)* %88
-  %91 = add i64 %90, 128
-  %92 = inttoptr i64 %91 to i64*
-  %93 = load i64, i64* %92
+  %90 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %88
+  %91 = getelementptr inbounds i8, i8 addrspace(1)* %90, i32 128
+  %92 = bitcast i8 addrspace(1)* %91 to i64 addrspace(1)*
+  %93 = load i64, i64 addrspace(1)* %92
   %94 = add i64 %93, 24
   %95 = inttoptr i64 %94 to i64*
   %96 = load i64, i64* %95
@@ -3091,15 +3091,15 @@ entry:
   %109 = getelementptr inbounds %"System.Type[]", %"System.Type[]" addrspace(1)* %101, i32 0, i32 3, i32 %102
   %110 = load %System.Type addrspace(1)*, %System.Type addrspace(1)* addrspace(1)* %109, align 8
   %111 = load %System.Type addrspace(1)*, %System.Type addrspace(1)** %arg1
-  %112 = bitcast %System.Type addrspace(1)* %110 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %112, null
+  %112 = bitcast %System.Type addrspace(1)* %110 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %112, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %113
 
 ; <label>:113                                     ; preds = %108
-  %114 = load i64, i64 addrspace(1)* %112
-  %115 = add i64 %114, 152
-  %116 = inttoptr i64 %115 to i64*
-  %117 = load i64, i64* %116
+  %114 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %112
+  %115 = getelementptr inbounds i8, i8 addrspace(1)* %114, i32 152
+  %116 = bitcast i8 addrspace(1)* %115 to i64 addrspace(1)*
+  %117 = load i64, i64 addrspace(1)* %116
   %118 = add i64 %117, 56
   %119 = inttoptr i64 %118 to i64*
   %120 = load i64, i64* %119
@@ -3746,15 +3746,15 @@ entry:
 
 ; <label>:47                                      ; preds = %43
   %48 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)** %loc0
-  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %49, null
+  %49 = bitcast %System.Text.StringBuilder addrspace(1)* %48 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %49, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %50
 
 ; <label>:50                                      ; preds = %47
-  %51 = load i64, i64 addrspace(1)* %49
-  %52 = add i64 %51, 64
-  %53 = inttoptr i64 %52 to i64*
-  %54 = load i64, i64* %53
+  %51 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %49
+  %52 = getelementptr inbounds i8, i8 addrspace(1)* %51, i32 64
+  %53 = bitcast i8 addrspace(1)* %52 to i64 addrspace(1)*
+  %54 = load i64, i64 addrspace(1)* %53
   %55 = add i64 %54, 0
   %56 = inttoptr i64 %55 to i64*
   %57 = load i64, i64* %56
@@ -4563,15 +4563,15 @@ entry:
 
 ; <label>:5                                       ; preds = %3
   %6 = load %System.__Canon addrspace(1)*, %System.__Canon addrspace(1)* addrspace(1)* %4, align 8
-  %7 = bitcast %System.__Canon addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.__Canon addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %5
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 64
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 64
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 16
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -4734,15 +4734,15 @@ entry:
   store %System.String addrspace(1)* %0, %System.String addrspace(1)** %loc0
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %loc0
   %2 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %3, null
+  %3 = bitcast %System.Globalization.CultureInfo addrspace(1)* %2 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %3, null
   br i1 %NullCheck, label %ThrowNullRef, label %4
 
 ; <label>:4                                       ; preds = %entry
-  %5 = load i64, i64 addrspace(1)* %3
-  %6 = add i64 %5, 64
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load i64, i64* %7
+  %5 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %3
+  %6 = getelementptr inbounds i8, i8 addrspace(1)* %5, i32 64
+  %7 = bitcast i8 addrspace(1)* %6 to i64 addrspace(1)*
+  %8 = load i64, i64 addrspace(1)* %7
   %9 = add i64 %8, 40
   %10 = inttoptr i64 %9 to i64*
   %11 = load i64, i64* %10
@@ -5239,15 +5239,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.StringComparer addrspace(1)*)*)(%System.StringComparer addrspace(1)* %1)
   %2 = load %System.CultureAwareComparer addrspace(1)*, %System.CultureAwareComparer addrspace(1)** %this
   %3 = load %System.Globalization.CultureInfo addrspace(1)*, %System.Globalization.CultureInfo addrspace(1)** %arg1
-  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Globalization.CultureInfo addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck, label %ThrowNullRef, label %5
 
 ; <label>:5                                       ; preds = %entry
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 72
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 72
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 16
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -5337,15 +5337,15 @@ entry:
   %16 = getelementptr inbounds %System.Globalization.CultureInfo, %System.Globalization.CultureInfo addrspace(1)* %14, i32 0, i32 7
   %17 = load %System.String addrspace(1)*, %System.String addrspace(1)* addrspace(1)* %16, align 8
   %18 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* (%System.String addrspace(1)*)*)(%System.String addrspace(1)* %17)
-  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Globalization.CultureInfo addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %15
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 72
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 72
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 16
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7396,15 +7396,15 @@ entry:
 ; <label>:76                                      ; preds = %74
   %77 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %75, i32 0, i32 0
   %78 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %77, align 8
-  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %79, null
+  %79 = bitcast %System.Text.StringBuilder addrspace(1)* %78 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %79, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %80
 
 ; <label>:80                                      ; preds = %76
-  %81 = load i64, i64 addrspace(1)* %79
-  %82 = add i64 %81, 64
-  %83 = inttoptr i64 %82 to i64*
-  %84 = load i64, i64* %83
+  %81 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %79
+  %82 = getelementptr inbounds i8, i8 addrspace(1)* %81, i32 64
+  %83 = bitcast i8 addrspace(1)* %82 to i64 addrspace(1)*
+  %84 = load i64, i64 addrspace(1)* %83
   %85 = add i64 %84, 0
   %86 = inttoptr i64 %85 to i64*
   %87 = load i64, i64* %86
@@ -7429,15 +7429,15 @@ entry:
 ; <label>:98                                      ; preds = %96
   %99 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %97, i32 0, i32 0
   %100 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %99, align 8
-  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %101, null
+  %101 = bitcast %System.Text.StringBuilder addrspace(1)* %100 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %101, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %102
 
 ; <label>:102                                     ; preds = %98
-  %103 = load i64, i64 addrspace(1)* %101
-  %104 = add i64 %103, 64
-  %105 = inttoptr i64 %104 to i64*
-  %106 = load i64, i64* %105
+  %103 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %101
+  %104 = getelementptr inbounds i8, i8 addrspace(1)* %103, i32 64
+  %105 = bitcast i8 addrspace(1)* %104 to i64 addrspace(1)*
+  %106 = load i64, i64 addrspace(1)* %105
   %107 = add i64 %106, 0
   %108 = inttoptr i64 %107 to i64*
   %109 = load i64, i64* %108
@@ -7604,15 +7604,15 @@ entry:
 ; <label>:16                                      ; preds = %14
   %17 = getelementptr inbounds %System.IO.PathHelper, %System.IO.PathHelper addrspace(1)* %15, i32 0, i32 0
   %18 = load %System.Text.StringBuilder addrspace(1)*, %System.Text.StringBuilder addrspace(1)* addrspace(1)* %17, align 8
-  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.Text.StringBuilder addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %20
 
 ; <label>:20                                      ; preds = %16
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 0
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -7826,15 +7826,15 @@ entry:
 
 ; <label>:26                                      ; preds = %22
   %27 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i64 addrspace(1)*
-  %NullCheck23 = icmp eq i64 addrspace(1)* %28, null
+  %28 = bitcast %System.Globalization.CultureInfo addrspace(1)* %27 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck23 = icmp eq i8 addrspace(1)* addrspace(1)* %28, null
   br i1 %NullCheck23, label %ThrowNullRef24, label %29
 
 ; <label>:29                                      ; preds = %26
-  %30 = load i64, i64 addrspace(1)* %28
-  %31 = add i64 %30, 72
-  %32 = inttoptr i64 %31 to i64*
-  %33 = load i64, i64* %32
+  %30 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %28
+  %31 = getelementptr inbounds i8, i8 addrspace(1)* %30, i32 72
+  %32 = bitcast i8 addrspace(1)* %31 to i64 addrspace(1)*
+  %33 = load i64, i64 addrspace(1)* %32
   %34 = add i64 %33, 16
   %35 = inttoptr i64 %34 to i64*
   %36 = load i64, i64* %35
@@ -7842,15 +7842,15 @@ entry:
   %38 = call %System.Globalization.CompareInfo addrspace(1)* %37(%System.Globalization.CultureInfo addrspace(1)* %27)
   %39 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %40 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %41, null
+  %41 = bitcast %System.Globalization.CompareInfo addrspace(1)* %38 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %41, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %42
 
 ; <label>:42                                      ; preds = %29
-  %43 = load i64, i64 addrspace(1)* %41
-  %44 = add i64 %43, 64
-  %45 = inttoptr i64 %44 to i64*
-  %46 = load i64, i64* %45
+  %43 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %41
+  %44 = getelementptr inbounds i8, i8 addrspace(1)* %43, i32 64
+  %45 = bitcast i8 addrspace(1)* %44 to i64 addrspace(1)*
+  %46 = load i64, i64 addrspace(1)* %45
   %47 = add i64 %46, 48
   %48 = inttoptr i64 %47 to i64*
   %49 = load i64, i64* %48
@@ -7863,15 +7863,15 @@ entry:
 
 ; <label>:55                                      ; preds = %22
   %56 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Globalization.CultureInfo addrspace(1)* %56 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %58
 
 ; <label>:58                                      ; preds = %55
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 72
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 72
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 16
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -7879,15 +7879,15 @@ entry:
   %67 = call %System.Globalization.CompareInfo addrspace(1)* %66(%System.Globalization.CultureInfo addrspace(1)* %56)
   %68 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %69 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.Globalization.CompareInfo addrspace(1)* %67 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %71
 
 ; <label>:71                                      ; preds = %58
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 64
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 64
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 48
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -7900,15 +7900,15 @@ entry:
 
 ; <label>:84                                      ; preds = %22
   %85 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i64 addrspace(1)*
-  %NullCheck15 = icmp eq i64 addrspace(1)* %86, null
+  %86 = bitcast %System.Globalization.CultureInfo addrspace(1)* %85 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck15 = icmp eq i8 addrspace(1)* addrspace(1)* %86, null
   br i1 %NullCheck15, label %ThrowNullRef16, label %87
 
 ; <label>:87                                      ; preds = %84
-  %88 = load i64, i64 addrspace(1)* %86
-  %89 = add i64 %88, 72
-  %90 = inttoptr i64 %89 to i64*
-  %91 = load i64, i64* %90
+  %88 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %86
+  %89 = getelementptr inbounds i8, i8 addrspace(1)* %88, i32 72
+  %90 = bitcast i8 addrspace(1)* %89 to i64 addrspace(1)*
+  %91 = load i64, i64 addrspace(1)* %90
   %92 = add i64 %91, 16
   %93 = inttoptr i64 %92 to i64*
   %94 = load i64, i64* %93
@@ -7916,15 +7916,15 @@ entry:
   %96 = call %System.Globalization.CompareInfo addrspace(1)* %95(%System.Globalization.CultureInfo addrspace(1)* %85)
   %97 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %98 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Globalization.CompareInfo addrspace(1)* %96 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %100
 
 ; <label>:100                                     ; preds = %87
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 48
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -7937,15 +7937,15 @@ entry:
 
 ; <label>:113                                     ; preds = %22
   %114 = call %System.Globalization.CultureInfo addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Globalization.CultureInfo addrspace(1)* ()*)()
-  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i64 addrspace(1)*
-  %NullCheck11 = icmp eq i64 addrspace(1)* %115, null
+  %115 = bitcast %System.Globalization.CultureInfo addrspace(1)* %114 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck11 = icmp eq i8 addrspace(1)* addrspace(1)* %115, null
   br i1 %NullCheck11, label %ThrowNullRef12, label %116
 
 ; <label>:116                                     ; preds = %113
-  %117 = load i64, i64 addrspace(1)* %115
-  %118 = add i64 %117, 72
-  %119 = inttoptr i64 %118 to i64*
-  %120 = load i64, i64* %119
+  %117 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %115
+  %118 = getelementptr inbounds i8, i8 addrspace(1)* %117, i32 72
+  %119 = bitcast i8 addrspace(1)* %118 to i64 addrspace(1)*
+  %120 = load i64, i64 addrspace(1)* %119
   %121 = add i64 %120, 16
   %122 = inttoptr i64 %121 to i64*
   %123 = load i64, i64* %122
@@ -7953,15 +7953,15 @@ entry:
   %125 = call %System.Globalization.CompareInfo addrspace(1)* %124(%System.Globalization.CultureInfo addrspace(1)* %114)
   %126 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
   %127 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %128, null
+  %128 = bitcast %System.Globalization.CompareInfo addrspace(1)* %125 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %128, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %129
 
 ; <label>:129                                     ; preds = %116
-  %130 = load i64, i64 addrspace(1)* %128
-  %131 = add i64 %130, 64
-  %132 = inttoptr i64 %131 to i64*
-  %133 = load i64, i64* %132
+  %130 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %128
+  %131 = getelementptr inbounds i8, i8 addrspace(1)* %130, i32 64
+  %132 = bitcast i8 addrspace(1)* %131 to i64 addrspace(1)*
+  %133 = load i64, i64 addrspace(1)* %132
   %134 = add i64 %133, 48
   %135 = inttoptr i64 %134 to i64*
   %136 = load i64, i64* %135
@@ -10112,15 +10112,15 @@ entry:
 
 ; <label>:15                                      ; preds = %7
   %16 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %17 = bitcast %System.String addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.String addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -11112,15 +11112,15 @@ entry:
 ; <label>:9                                       ; preds = %entry
   %10 = load %System.Security.Policy.PolicyStatement addrspace(1)*, %System.Security.Policy.PolicyStatement addrspace(1)** %this
   %11 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)** %arg1
-  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %12, null
+  %12 = bitcast %System.Security.PermissionSet addrspace(1)* %11 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %12, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %13
 
 ; <label>:13                                      ; preds = %9
-  %14 = load i64, i64 addrspace(1)* %12
-  %15 = add i64 %14, 72
-  %16 = inttoptr i64 %15 to i64*
-  %17 = load i64, i64* %16
+  %14 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %12
+  %15 = getelementptr inbounds i8, i8 addrspace(1)* %14, i32 72
+  %16 = bitcast i8 addrspace(1)* %15 to i64 addrspace(1)*
+  %17 = load i64, i64 addrspace(1)* %16
   %18 = add i64 %17, 32
   %19 = inttoptr i64 %18 to i64*
   %20 = load i64, i64* %19
@@ -11626,15 +11626,15 @@ entry:
 ; <label>:4                                       ; preds = %entry
   %5 = getelementptr inbounds %System.Security.Policy.PolicyStatement, %System.Security.Policy.PolicyStatement addrspace(1)* %3, i32 0, i32 1
   %6 = load %System.Security.PermissionSet addrspace(1)*, %System.Security.PermissionSet addrspace(1)* addrspace(1)* %5, align 8
-  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.Security.PermissionSet addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %8
 
 ; <label>:8                                       ; preds = %4
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 72
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 72
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 32
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -11751,15 +11751,15 @@ entry:
   store %System.String addrspace(1)* %param0, %System.String addrspace(1)** %arg0
   %0 = call %System.IO.TextWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.TextWriter addrspace(1)* ()*)()
   %1 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg0
-  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.IO.TextWriter addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 104
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 104
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 8
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12146,15 +12146,15 @@ entry:
   %5 = call %System.Text.Encoding addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.Encoding addrspace(1)* ()*)()
   %6 = call %System.IO.StreamWriter addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.IO.StreamWriter addrspace(1)* (i64)*)(i64 NORMALIZED_ADDRESS)
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.IO.StreamWriter addrspace(1)*, %System.IO.Stream addrspace(1)*, %System.Text.Encoding addrspace(1)*, i32, i8)*)(%System.IO.StreamWriter addrspace(1)* %6, %System.IO.Stream addrspace(1)* %4, %System.Text.Encoding addrspace(1)* %5, i32 256, i8 1)
-  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %7, null
+  %7 = bitcast %System.IO.StreamWriter addrspace(1)* %6 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %7, null
   br i1 %NullCheck, label %ThrowNullRef, label %8
 
 ; <label>:8                                       ; preds = %3
-  %9 = load i64, i64 addrspace(1)* %7
-  %10 = add i64 %9, 120
-  %11 = inttoptr i64 %10 to i64*
-  %12 = load i64, i64* %11
+  %9 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %7
+  %10 = getelementptr inbounds i8, i8 addrspace(1)* %9, i32 120
+  %11 = bitcast i8 addrspace(1)* %10 to i64 addrspace(1)*
+  %12 = load i64, i64 addrspace(1)* %11
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i64*
   %15 = load i64, i64* %14
@@ -12305,15 +12305,15 @@ entry:
   store %System.Text.EncodingProvider addrspace(1)* %22, %System.Text.EncodingProvider addrspace(1)** %loc1
   %23 = load %System.Text.EncodingProvider addrspace(1)*, %System.Text.EncodingProvider addrspace(1)** %loc1
   %24 = load i32, i32* %arg0
-  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %25, null
+  %25 = bitcast %System.Text.EncodingProvider addrspace(1)* %23 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %25, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %26
 
 ; <label>:26                                      ; preds = %20
-  %27 = load i64, i64 addrspace(1)* %25
-  %28 = add i64 %27, 64
-  %29 = inttoptr i64 %28 to i64*
-  %30 = load i64, i64* %29
+  %27 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %25
+  %28 = getelementptr inbounds i8, i8 addrspace(1)* %27, i32 64
+  %29 = bitcast i8 addrspace(1)* %28 to i64 addrspace(1)*
+  %30 = load i64, i64 addrspace(1)* %29
   %31 = add i64 %30, 40
   %32 = inttoptr i64 %31 to i64*
   %33 = load i64, i64* %32
@@ -12410,15 +12410,15 @@ entry:
   store i32 addrspace(1)* %param4, i32 addrspace(1)** %arg4
   %0 = load %System.Collections.Hashtable addrspace(1)*, %System.Collections.Hashtable addrspace(1)** %this
   %1 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %2, null
+  %2 = bitcast %System.Collections.Hashtable addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %2, null
   br i1 %NullCheck, label %ThrowNullRef, label %3
 
 ; <label>:3                                       ; preds = %entry
-  %4 = load i64, i64 addrspace(1)* %2
-  %5 = add i64 %4, 72
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load i64, i64* %6
+  %4 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %2
+  %5 = getelementptr inbounds i8, i8 addrspace(1)* %4, i32 72
+  %6 = bitcast i8 addrspace(1)* %5 to i64 addrspace(1)*
+  %7 = load i64, i64 addrspace(1)* %6
   %8 = add i64 %7, 40
   %9 = inttoptr i64 %8 to i64*
   %10 = load i64, i64* %9
@@ -12509,15 +12509,15 @@ entry:
 
 ; <label>:15                                      ; preds = %1
   %16 = load %System.Object addrspace(1)*, %System.Object addrspace(1)** %arg1
-  %17 = bitcast %System.Object addrspace(1)* %16 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %17, null
+  %17 = bitcast %System.Object addrspace(1)* %16 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %17, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %18
 
 ; <label>:18                                      ; preds = %15
-  %19 = load i64, i64 addrspace(1)* %17
-  %20 = add i64 %19, 64
-  %21 = inttoptr i64 %20 to i64*
-  %22 = load i64, i64* %21
+  %19 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %17
+  %20 = getelementptr inbounds i8, i8 addrspace(1)* %19, i32 64
+  %21 = bitcast i8 addrspace(1)* %20 to i64 addrspace(1)*
+  %22 = load i64, i64 addrspace(1)* %21
   %23 = add i64 %22, 16
   %24 = inttoptr i64 %23 to i64*
   %25 = load i64, i64* %24
@@ -12657,15 +12657,15 @@ entry:
 
 ; <label>:20                                      ; preds = %15
   %21 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
-  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %22, null
+  %22 = bitcast %System.Text.UTF8Encoding addrspace(1)* %21 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %22, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %23
 
 ; <label>:23                                      ; preds = %20
-  %24 = load i64, i64 addrspace(1)* %22
-  %25 = add i64 %24, 64
-  %26 = inttoptr i64 %25 to i64*
-  %27 = load i64, i64* %26
+  %24 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %22
+  %25 = getelementptr inbounds i8, i8 addrspace(1)* %24, i32 64
+  %26 = bitcast i8 addrspace(1)* %25 to i64 addrspace(1)*
+  %27 = load i64, i64 addrspace(1)* %26
   %28 = add i64 %27, 32
   %29 = inttoptr i64 %28 to i64*
   %30 = load i64, i64* %29
@@ -12734,15 +12734,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.Encoding, %System.Text.Encoding addrspace(1)* %11, i32 0, i32 4
   store i32 %12, i32 addrspace(1)* %14
   %15 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)** %this
-  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.Encoding addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13201,15 +13201,15 @@ entry:
 
 ; <label>:17                                      ; preds = %4
   %18 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)** %arg1
-  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %19, null
+  %19 = bitcast %System.IO.Stream addrspace(1)* %18 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %19, null
   br i1 %NullCheck, label %ThrowNullRef, label %20
 
 ; <label>:20                                      ; preds = %17
-  %21 = load i64, i64 addrspace(1)* %19
-  %22 = add i64 %21, 64
-  %23 = inttoptr i64 %22 to i64*
-  %24 = load i64, i64* %23
+  %21 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %19
+  %22 = getelementptr inbounds i8, i8 addrspace(1)* %21, i32 64
+  %23 = bitcast i8 addrspace(1)* %22 to i64 addrspace(1)*
+  %24 = load i64, i64 addrspace(1)* %23
   %25 = add i64 %24, 56
   %26 = inttoptr i64 %25 to i64*
   %27 = load i64, i64* %26
@@ -13321,15 +13321,15 @@ entry:
 ; <label>:10                                      ; preds = %6
   %11 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %9, i32 0, i32 4
   %12 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.Encoding addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 96
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 96
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13369,15 +13369,15 @@ entry:
   %39 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %37, i32 0, i32 4
   %40 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %39, align 8
   %41 = load i32, i32* %arg3
-  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i64 addrspace(1)*
-  %NullCheck13 = icmp eq i64 addrspace(1)* %42, null
+  %42 = bitcast %System.Text.Encoding addrspace(1)* %40 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck13 = icmp eq i8 addrspace(1)* addrspace(1)* %42, null
   br i1 %NullCheck13, label %ThrowNullRef14, label %43
 
 ; <label>:43                                      ; preds = %38
-  %44 = load i64, i64 addrspace(1)* %42
-  %45 = add i64 %44, 96
-  %46 = inttoptr i64 %45 to i64*
-  %47 = load i64, i64* %46
+  %44 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %42
+  %45 = getelementptr inbounds i8, i8 addrspace(1)* %44, i32 96
+  %46 = bitcast i8 addrspace(1)* %45 to i64 addrspace(1)*
+  %47 = load i64, i64 addrspace(1)* %46
   %48 = add i64 %47, 16
   %49 = inttoptr i64 %48 to i64*
   %50 = load i64, i64* %49
@@ -13406,15 +13406,15 @@ entry:
 ; <label>:62                                      ; preds = %59
   %63 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %61, i32 0, i32 3
   %64 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %63, align 8
-  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i64 addrspace(1)*
-  %NullCheck21 = icmp eq i64 addrspace(1)* %65, null
+  %65 = bitcast %System.IO.Stream addrspace(1)* %64 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck21 = icmp eq i8 addrspace(1)* addrspace(1)* %65, null
   br i1 %NullCheck21, label %ThrowNullRef22, label %66
 
 ; <label>:66                                      ; preds = %62
-  %67 = load i64, i64 addrspace(1)* %65
-  %68 = add i64 %67, 64
-  %69 = inttoptr i64 %68 to i64*
-  %70 = load i64, i64* %69
+  %67 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %65
+  %68 = getelementptr inbounds i8, i8 addrspace(1)* %67, i32 64
+  %69 = bitcast i8 addrspace(1)* %68 to i64 addrspace(1)*
+  %70 = load i64, i64 addrspace(1)* %69
   %71 = add i64 %70, 40
   %72 = inttoptr i64 %71 to i64*
   %73 = load i64, i64* %72
@@ -13432,15 +13432,15 @@ entry:
 ; <label>:80                                      ; preds = %78
   %81 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %79, i32 0, i32 3
   %82 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %81, align 8
-  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i64 addrspace(1)*
-  %NullCheck25 = icmp eq i64 addrspace(1)* %83, null
+  %83 = bitcast %System.IO.Stream addrspace(1)* %82 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck25 = icmp eq i8 addrspace(1)* addrspace(1)* %83, null
   br i1 %NullCheck25, label %ThrowNullRef26, label %84
 
 ; <label>:84                                      ; preds = %80
-  %85 = load i64, i64 addrspace(1)* %83
-  %86 = add i64 %85, 72
-  %87 = inttoptr i64 %86 to i64*
-  %88 = load i64, i64* %87
+  %85 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %83
+  %86 = getelementptr inbounds i8, i8 addrspace(1)* %85, i32 72
+  %87 = bitcast i8 addrspace(1)* %86 to i64 addrspace(1)*
+  %88 = load i64, i64 addrspace(1)* %87
   %89 = add i64 %88, 8
   %90 = inttoptr i64 %89 to i64*
   %91 = load i64, i64* %90
@@ -13553,15 +13553,15 @@ entry:
 ; <label>:1                                       ; preds = %entry
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
-  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %4, null
+  %4 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %4, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %5
 
 ; <label>:5                                       ; preds = %1
-  %6 = load i64, i64 addrspace(1)* %4
-  %7 = add i64 %6, 96
-  %8 = inttoptr i64 %7 to i64*
-  %9 = load i64, i64* %8
+  %6 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %4
+  %7 = getelementptr inbounds i8, i8 addrspace(1)* %6, i32 96
+  %8 = bitcast i8 addrspace(1)* %7 to i64 addrspace(1)*
+  %9 = load i64, i64 addrspace(1)* %8
   %10 = add i64 %9, 8
   %11 = inttoptr i64 %10 to i64*
   %12 = load i64, i64* %11
@@ -13649,15 +13649,15 @@ entry:
   %14 = getelementptr inbounds %System.Text.EncoderNLS, %System.Text.EncoderNLS addrspace(1)* %6, i32 0, i32 1
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Text.EncoderFallback addrspace(1)* addrspace(1)*, %System.Text.EncoderFallback addrspace(1)*)*)(%System.Text.EncoderFallback addrspace(1)* addrspace(1)* %14, %System.Text.EncoderFallback addrspace(1)* %12)
   %15 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i64 addrspace(1)*
-  %NullCheck7 = icmp eq i64 addrspace(1)* %16, null
+  %16 = bitcast %System.Text.EncoderNLS addrspace(1)* %15 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck7 = icmp eq i8 addrspace(1)* addrspace(1)* %16, null
   br i1 %NullCheck7, label %ThrowNullRef8, label %17
 
 ; <label>:17                                      ; preds = %13
-  %18 = load i64, i64 addrspace(1)* %16
-  %19 = add i64 %18, 64
-  %20 = inttoptr i64 %19 to i64*
-  %21 = load i64, i64* %20
+  %18 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %16
+  %19 = getelementptr inbounds i8, i8 addrspace(1)* %18, i32 64
+  %20 = bitcast i8 addrspace(1)* %19 to i64 addrspace(1)*
+  %21 = load i64, i64 addrspace(1)* %20
   %22 = add i64 %21, 32
   %23 = inttoptr i64 %22 to i64*
   %24 = load i64, i64* %23
@@ -13753,15 +13753,15 @@ entry:
 ; <label>:10                                      ; preds = %8
   %11 = getelementptr inbounds %"System.Text.UTF8Encoding+UTF8Encoder", %"System.Text.UTF8Encoding+UTF8Encoder" addrspace(1)* %9, i32 0, i32 2
   %12 = load %System.Text.EncoderFallbackBuffer addrspace(1)*, %System.Text.EncoderFallbackBuffer addrspace(1)* addrspace(1)* %11, align 8
-  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %13, null
+  %13 = bitcast %System.Text.EncoderFallbackBuffer addrspace(1)* %12 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %13, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %14
 
 ; <label>:14                                      ; preds = %10
-  %15 = load i64, i64 addrspace(1)* %13
-  %16 = add i64 %15, 72
-  %17 = inttoptr i64 %16 to i64*
-  %18 = load i64, i64* %17
+  %15 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %13
+  %16 = getelementptr inbounds i8, i8 addrspace(1)* %15, i32 72
+  %17 = bitcast i8 addrspace(1)* %16 to i64 addrspace(1)*
+  %18 = load i64, i64 addrspace(1)* %17
   %19 = add i64 %18, 8
   %20 = inttoptr i64 %19 to i64*
   %21 = load i64, i64* %20
@@ -13806,15 +13806,15 @@ entry:
   %2 = getelementptr inbounds %System.Text.ConsoleEncoding, %System.Text.ConsoleEncoding addrspace(1)* %0, i32 0, i32 8
   %3 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %2, align 8
   %4 = load i32, i32* %arg1
-  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %5, null
+  %5 = bitcast %System.Text.Encoding addrspace(1)* %3 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %5, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %6
 
 ; <label>:6                                       ; preds = %1
-  %7 = load i64, i64 addrspace(1)* %5
-  %8 = add i64 %7, 96
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load i64, i64* %9
+  %7 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %5
+  %8 = getelementptr inbounds i8, i8 addrspace(1)* %7, i32 96
+  %9 = bitcast i8 addrspace(1)* %8 to i64 addrspace(1)*
+  %10 = load i64, i64 addrspace(1)* %9
   %11 = add i64 %10, 16
   %12 = inttoptr i64 %11 to i64*
   %13 = load i64, i64* %12
@@ -13862,15 +13862,15 @@ entry:
   %11 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %12 = bitcast %System.Text.UTF8Encoding addrspace(1)* %11 to %System.Text.Encoding addrspace(1)*
   %13 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %12)
-  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %14, null
+  %14 = bitcast %System.Text.EncoderFallback addrspace(1)* %13 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %14, null
   br i1 %NullCheck, label %ThrowNullRef, label %15
 
 ; <label>:15                                      ; preds = %7
-  %16 = load i64, i64 addrspace(1)* %14
-  %17 = add i64 %16, 64
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load i64, i64* %18
+  %16 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %14
+  %17 = getelementptr inbounds i8, i8 addrspace(1)* %16, i32 64
+  %18 = bitcast i8 addrspace(1)* %17 to i64 addrspace(1)*
+  %19 = load i64, i64 addrspace(1)* %18
   %20 = add i64 %19, 40
   %21 = inttoptr i64 %20 to i64*
   %22 = load i64, i64* %21
@@ -13884,15 +13884,15 @@ entry:
   %28 = load %System.Text.UTF8Encoding addrspace(1)*, %System.Text.UTF8Encoding addrspace(1)** %this
   %29 = bitcast %System.Text.UTF8Encoding addrspace(1)* %28 to %System.Text.Encoding addrspace(1)*
   %30 = call %System.Text.EncoderFallback addrspace(1)* inttoptr (i64 NORMALIZED_ADDRESS to %System.Text.EncoderFallback addrspace(1)* (%System.Text.Encoding addrspace(1)*)*)(%System.Text.Encoding addrspace(1)* %29)
-  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %31, null
+  %31 = bitcast %System.Text.EncoderFallback addrspace(1)* %30 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %31, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %32
 
 ; <label>:32                                      ; preds = %26
-  %33 = load i64, i64 addrspace(1)* %31
-  %34 = add i64 %33, 64
-  %35 = inttoptr i64 %34 to i64*
-  %36 = load i64, i64* %35
+  %33 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %31
+  %34 = getelementptr inbounds i8, i8 addrspace(1)* %33, i32 64
+  %35 = bitcast i8 addrspace(1)* %34 to i64 addrspace(1)*
+  %36 = load i64, i64 addrspace(1)* %35
   %37 = add i64 %36, 40
   %38 = inttoptr i64 %37 to i64*
   %39 = load i64, i64* %38
@@ -14151,15 +14151,15 @@ entry:
 ; <label>:37                                      ; preds = %34
   %38 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %36, i32 0, i32 4
   %39 = load %System.Text.Encoding addrspace(1)*, %System.Text.Encoding addrspace(1)* addrspace(1)* %38, align 8
-  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i64 addrspace(1)*
-  %NullCheck9 = icmp eq i64 addrspace(1)* %40, null
+  %40 = bitcast %System.Text.Encoding addrspace(1)* %39 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck9 = icmp eq i8 addrspace(1)* addrspace(1)* %40, null
   br i1 %NullCheck9, label %ThrowNullRef10, label %41
 
 ; <label>:41                                      ; preds = %37
-  %42 = load i64, i64 addrspace(1)* %40
-  %43 = add i64 %42, 64
-  %44 = inttoptr i64 %43 to i64*
-  %45 = load i64, i64* %44
+  %42 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %40
+  %43 = getelementptr inbounds i8, i8 addrspace(1)* %42, i32 64
+  %44 = bitcast i8 addrspace(1)* %43 to i64 addrspace(1)*
+  %45 = load i64, i64 addrspace(1)* %44
   %46 = add i64 %45, 40
   %47 = inttoptr i64 %46 to i64*
   %48 = load i64, i64* %47
@@ -14196,15 +14196,15 @@ entry:
   %67 = load i32, i32 addrspace(1)* %66
   %68 = zext i32 %67 to i64
   %69 = trunc i64 %68 to i32
-  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i64 addrspace(1)*
-  %NullCheck17 = icmp eq i64 addrspace(1)* %70, null
+  %70 = bitcast %System.IO.Stream addrspace(1)* %62 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck17 = icmp eq i8 addrspace(1)* addrspace(1)* %70, null
   br i1 %NullCheck17, label %ThrowNullRef18, label %71
 
 ; <label>:71                                      ; preds = %65
-  %72 = load i64, i64 addrspace(1)* %70
-  %73 = add i64 %72, 88
-  %74 = inttoptr i64 %73 to i64*
-  %75 = load i64, i64* %74
+  %72 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %70
+  %73 = getelementptr inbounds i8, i8 addrspace(1)* %72, i32 88
+  %74 = bitcast i8 addrspace(1)* %73 to i64 addrspace(1)*
+  %75 = load i64, i64 addrspace(1)* %74
   %76 = add i64 %75, 56
   %77 = inttoptr i64 %76 to i64*
   %78 = load i64, i64* %77
@@ -14243,15 +14243,15 @@ entry:
   %96 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %95, align 8
   %97 = load i8, i8* %arg2
   %98 = zext i8 %97 to i32
-  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i64 addrspace(1)*
-  %NullCheck27 = icmp eq i64 addrspace(1)* %99, null
+  %99 = bitcast %System.Text.Encoder addrspace(1)* %84 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck27 = icmp eq i8 addrspace(1)* addrspace(1)* %99, null
   br i1 %NullCheck27, label %ThrowNullRef28, label %100
 
 ; <label>:100                                     ; preds = %94
-  %101 = load i64, i64 addrspace(1)* %99
-  %102 = add i64 %101, 64
-  %103 = inttoptr i64 %102 to i64*
-  %104 = load i64, i64* %103
+  %101 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %99
+  %102 = getelementptr inbounds i8, i8 addrspace(1)* %101, i32 64
+  %103 = bitcast i8 addrspace(1)* %102 to i64 addrspace(1)*
+  %104 = load i64, i64 addrspace(1)* %103
   %105 = add i64 %104, 56
   %106 = inttoptr i64 %105 to i64*
   %107 = load i64, i64* %106
@@ -14286,15 +14286,15 @@ entry:
   %123 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %121, i32 0, i32 6
   %124 = load %"System.Byte[]" addrspace(1)*, %"System.Byte[]" addrspace(1)* addrspace(1)* %123, align 8
   %125 = load i32, i32* %loc1
-  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i64 addrspace(1)*
-  %NullCheck35 = icmp eq i64 addrspace(1)* %126, null
+  %126 = bitcast %System.IO.Stream addrspace(1)* %120 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck35 = icmp eq i8 addrspace(1)* addrspace(1)* %126, null
   br i1 %NullCheck35, label %ThrowNullRef36, label %127
 
 ; <label>:127                                     ; preds = %122
-  %128 = load i64, i64 addrspace(1)* %126
-  %129 = add i64 %128, 88
-  %130 = inttoptr i64 %129 to i64*
-  %131 = load i64, i64* %130
+  %128 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %126
+  %129 = getelementptr inbounds i8, i8 addrspace(1)* %128, i32 88
+  %130 = bitcast i8 addrspace(1)* %129 to i64 addrspace(1)*
+  %131 = load i64, i64 addrspace(1)* %130
   %132 = add i64 %131, 56
   %133 = inttoptr i64 %132 to i64*
   %134 = load i64, i64* %133
@@ -14316,15 +14316,15 @@ entry:
 ; <label>:142                                     ; preds = %140
   %143 = getelementptr inbounds %System.IO.StreamWriter, %System.IO.StreamWriter addrspace(1)* %141, i32 0, i32 3
   %144 = load %System.IO.Stream addrspace(1)*, %System.IO.Stream addrspace(1)* addrspace(1)* %143, align 8
-  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i64 addrspace(1)*
-  %NullCheck39 = icmp eq i64 addrspace(1)* %145, null
+  %145 = bitcast %System.IO.Stream addrspace(1)* %144 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck39 = icmp eq i8 addrspace(1)* addrspace(1)* %145, null
   br i1 %NullCheck39, label %ThrowNullRef40, label %146
 
 ; <label>:146                                     ; preds = %142
-  %147 = load i64, i64 addrspace(1)* %145
-  %148 = add i64 %147, 80
-  %149 = inttoptr i64 %148 to i64*
-  %150 = load i64, i64* %149
+  %147 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %145
+  %148 = getelementptr inbounds i8, i8 addrspace(1)* %147, i32 80
+  %149 = bitcast i8 addrspace(1)* %148 to i64 addrspace(1)*
+  %150 = load i64, i64 addrspace(1)* %149
   %151 = add i64 %150, 24
   %152 = inttoptr i64 %151 to i64*
   %153 = load i64, i64* %152
@@ -14490,15 +14490,15 @@ entry:
   call void inttoptr (i64 NORMALIZED_ADDRESS to void (%System.Object addrspace(1)* addrspace(1)*, %System.Object addrspace(1)*)*)(%System.Object addrspace(1)* addrspace(1)* %3, %System.Object addrspace(1)* %1)
   %4 = load %System.IO.SyncTextWriter addrspace(1)*, %System.IO.SyncTextWriter addrspace(1)** %this
   %5 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)** %arg1
-  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i64 addrspace(1)*
-  %NullCheck1 = icmp eq i64 addrspace(1)* %6, null
+  %6 = bitcast %System.IO.TextWriter addrspace(1)* %5 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck1 = icmp eq i8 addrspace(1)* addrspace(1)* %6, null
   br i1 %NullCheck1, label %ThrowNullRef2, label %7
 
 ; <label>:7                                       ; preds = %2
-  %8 = load i64, i64 addrspace(1)* %6
-  %9 = add i64 %8, 64
-  %10 = inttoptr i64 %9 to i64*
-  %11 = load i64, i64* %10
+  %8 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %6
+  %9 = getelementptr inbounds i8, i8 addrspace(1)* %8, i32 64
+  %10 = bitcast i8 addrspace(1)* %9 to i64 addrspace(1)*
+  %11 = load i64, i64 addrspace(1)* %10
   %12 = add i64 %11, 32
   %13 = inttoptr i64 %12 to i64*
   %14 = load i64, i64* %13
@@ -14789,15 +14789,15 @@ entry:
   %8 = getelementptr inbounds %System.IO.SyncTextWriter, %System.IO.SyncTextWriter addrspace(1)* %6, i32 0, i32 4
   %9 = load %System.IO.TextWriter addrspace(1)*, %System.IO.TextWriter addrspace(1)* addrspace(1)* %8, align 8
   %10 = load %System.String addrspace(1)*, %System.String addrspace(1)** %arg1
-  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i64 addrspace(1)*
-  %NullCheck3 = icmp eq i64 addrspace(1)* %11, null
+  %11 = bitcast %System.IO.TextWriter addrspace(1)* %9 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck3 = icmp eq i8 addrspace(1)* addrspace(1)* %11, null
   br i1 %NullCheck3, label %ThrowNullRef4, label %12
 
 ; <label>:12                                      ; preds = %7
-  %13 = load i64, i64 addrspace(1)* %11
-  %14 = add i64 %13, 104
-  %15 = inttoptr i64 %14 to i64*
-  %16 = load i64, i64* %15
+  %13 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %11
+  %14 = getelementptr inbounds i8, i8 addrspace(1)* %13, i32 104
+  %15 = bitcast i8 addrspace(1)* %14 to i64 addrspace(1)*
+  %16 = load i64, i64 addrspace(1)* %15
   %17 = add i64 %16, 8
   %18 = inttoptr i64 %17 to i64*
   %19 = load i64, i64* %18
@@ -15619,15 +15619,15 @@ entry:
   %150 = load i32, i32* %loc0
   %151 = load i8, i8* %arg6
   %152 = zext i8 %151 to i32
-  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i64 addrspace(1)*
-  %NullCheck19 = icmp eq i64 addrspace(1)* %153, null
+  %153 = bitcast %System.Text.EncoderNLS addrspace(1)* %137 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck19 = icmp eq i8 addrspace(1)* addrspace(1)* %153, null
   br i1 %NullCheck19, label %ThrowNullRef20, label %154
 
 ; <label>:154                                     ; preds = %136
-  %155 = load i64, i64 addrspace(1)* %153
-  %156 = add i64 %155, 72
-  %157 = inttoptr i64 %156 to i64*
-  %158 = load i64, i64* %157
+  %155 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %153
+  %156 = getelementptr inbounds i8, i8 addrspace(1)* %155, i32 72
+  %157 = bitcast i8 addrspace(1)* %156 to i64 addrspace(1)*
+  %158 = load i64, i64 addrspace(1)* %157
   %159 = add i64 %158, 0
   %160 = inttoptr i64 %159 to i64*
   %161 = load i64, i64* %160
@@ -15806,15 +15806,15 @@ entry:
   %54 = load i8*, i8** %arg3
   %55 = load i32, i32* %arg4
   %56 = load %System.Text.EncoderNLS addrspace(1)*, %System.Text.EncoderNLS addrspace(1)** %this
-  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i64 addrspace(1)*
-  %NullCheck5 = icmp eq i64 addrspace(1)* %57, null
+  %57 = bitcast %System.Text.Encoding addrspace(1)* %51 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck5 = icmp eq i8 addrspace(1)* addrspace(1)* %57, null
   br i1 %NullCheck5, label %ThrowNullRef6, label %58
 
 ; <label>:58                                      ; preds = %49
-  %59 = load i64, i64 addrspace(1)* %57
-  %60 = add i64 %59, 80
-  %61 = inttoptr i64 %60 to i64*
-  %62 = load i64, i64* %61
+  %59 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %57
+  %60 = getelementptr inbounds i8, i8 addrspace(1)* %59, i32 80
+  %61 = bitcast i8 addrspace(1)* %60 to i64 addrspace(1)*
+  %62 = load i64, i64 addrspace(1)* %61
   %63 = add i64 %62, 32
   %64 = inttoptr i64 %63 to i64*
   %65 = load i64, i64* %64
@@ -16168,15 +16168,15 @@ entry:
   %this = alloca %System.IO.ConsoleStream addrspace(1)*
   store %System.IO.ConsoleStream addrspace(1)* %param0, %System.IO.ConsoleStream addrspace(1)** %this
   %0 = load %System.IO.ConsoleStream addrspace(1)*, %System.IO.ConsoleStream addrspace(1)** %this
-  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i64 addrspace(1)*
-  %NullCheck = icmp eq i64 addrspace(1)* %1, null
+  %1 = bitcast %System.IO.ConsoleStream addrspace(1)* %0 to i8 addrspace(1)* addrspace(1)*
+  %NullCheck = icmp eq i8 addrspace(1)* addrspace(1)* %1, null
   br i1 %NullCheck, label %ThrowNullRef, label %2
 
 ; <label>:2                                       ; preds = %entry
-  %3 = load i64, i64 addrspace(1)* %1
-  %4 = add i64 %3, 64
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5
+  %3 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* %1
+  %4 = getelementptr inbounds i8, i8 addrspace(1)* %3, i32 64
+  %5 = bitcast i8 addrspace(1)* %4 to i64 addrspace(1)*
+  %6 = load i64, i64 addrspace(1)* %5
   %7 = add i64 %6, 56
   %8 = inttoptr i64 %7 to i64*
   %9 = load i64, i64* %8


### PR DESCRIPTION
Treat the GCness of the address and the GCness of the loaded value independently.
Use GC pointer (to i8) rather than integer when asked to create a GC pointer destination.

Lots of IR diffs; all are places where we're now generating a GC pointer as requested rather than an i64.
Needed to unblock #257.
